### PR TITLE
add progress bar and unlocked amount per scottye

### DIFF
--- a/src/components/ProjectCards.astro
+++ b/src/components/ProjectCards.astro
@@ -1,6 +1,7 @@
 ---
 import DonationCardComponent from './DonationCardComponent.astro';
 import { LockSection } from './LockSection';
+import ProgressBar from './atoms/ProgressBar.astro';
 
 export interface CardProps {
   currentAmount: number;
@@ -30,6 +31,7 @@ const { projectData } = Astro.props;
     />
   </div>
   <div class="relative donation-card-content">
+    <ProgressBar maxNumber={100} currentNumber={100} backgroundType="image" />
     <div class="donation-card-subheading mt-2">
       Above and Beyond
     </div>
@@ -37,6 +39,7 @@ const { projectData } = Astro.props;
       <div class="donation-card-heading">Opportunity Eight</div>
       <div class="flex items-center">
         <LockSection client:load fundingStatus="funded" />
+        <span class="ml-2 sus-green-text font-medium">$2,000,000 +</span>
       </div>
     </div>
     <p class="donation-card-description">


### PR DESCRIPTION
addresses Scottye's request based on feedback from Watermark here: https://seedcompany.slack.com/archives/C09A3AYMY75/p1761327263557499

On Opportunity 8, can we add the green bar like the other completed opportunities and just not include the “% funded”? Also, next to the padlock, can we say “2,000,000+”? Since we are talking about our expectations being exceeded, I want it to still feel like a completed opportunity.