### PR TITLE
Use `~/` for src paths

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -13,6 +13,10 @@
         "schema": "./schema.graphql",
       },
     ],
+    "baseUrl": ".",
+    "paths": {
+      "~/*": ["./src/*"]
+    }
   },
   "include": [".astro/types.d.ts", "**/*", "*.mjs", ".prettierrc.mjs"],
   "exclude": ["dist"]


### PR DESCRIPTION
A common setup. But I prefer `~/` as it is more distinct than `@/`, which is like a library with an empty name. Plus `~/` means home dir on unix, so I think it translates well.