### PR TITLE
Switch to extend sanity client with proxy

### DIFF
--- a/src/integrations/sanity/client.ts
+++ b/src/integrations/sanity/client.ts
@@ -10,6 +10,18 @@ const baseClient = _configuredClient as unknown as SanityClient;
 
 const imageBuilder = imageUrlBuilder(baseClient);
 
-export const sanityClient = Object.assign(Object.create(baseClient) as SanityClient, {
+const extra = {
   image: (source: SanityImageSource) => imageBuilder.image(source),
-});
+};
+
+export const sanityClient = new Proxy(baseClient, {
+  get(_, p) {
+    if (p in extra) {
+      return extra[p as keyof typeof extra];
+    }
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+    const out = Reflect.get(baseClient, p);
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-return,@typescript-eslint/no-unsafe-call,@typescript-eslint/no-unsafe-member-access
+    return typeof out === 'function' ? out.bind(baseClient) : out;
+  },
+}) as SanityClient & typeof extra;


### PR DESCRIPTION
Fixes regression from 3399baed40ace10c129746bccb55e5117275b80c, where I switched to wrapping/extending the base client instead of manually exposing the fetch method.

`Object.create()` doesn't work with native private properties, which `SanityClient` has.
So instead we'll use a `Proxy` to wrap the client. This allows us to have extra properties/methods, and anything in the base client method will be forwarded transparently.