### PR TITLE
Update the Thank You page

### DIFF
--- a/src/pages/thank-you.astro
+++ b/src/pages/thank-you.astro
@@ -1,15 +1,27 @@
 ---
 import Layout from '../layouts/Layout.astro';
 import { styled } from 'styled-system/jsx';
+import { Link } from '~/common/ui';
 ---
 
 <Layout>
-  <styled.main css={{ textAlign: 'center', p: '8', bgColor: 'primary.solid.bg', h: 'dvh' }}>
+  <styled.main
+    css={{
+      p: '8',
+      bgColor: 'primary.solid.bg',
+      minH: 'dvh',
+      textAlign: 'center',
+      display: 'grid',
+      placeContent: 'center',
+    }}
+  >
     <styled.h1 css={{ textStyle: 'title1', fontSize: '5xl' }}>Thank You!</styled.h1>
     <styled.p css={{ p: '2' }}>
       Your receipt will arrive in your inbox shortly. If your donation is an ACH transfer, it may
-      take several business days. For any additional questions or year-end giving statements, please
-      contact Seed Company at <a href="mailto:info@tsco.org">info@tsco.org</a>.
+      take several business days.
+      <br />
+      For any additional questions or year-end giving statements, please contact Seed Company at
+      <Link href="mailto:info@tsco.org">info@tsco.org</Link>.
     </styled.p>
     <script>
       if (window.location.search) {


### PR DESCRIPTION
Very minimal refactor to make the Thank you page look better and migrate away from Tailwind
Current: 
<img width="1911" height="991" alt="image" src="https://github.com/user-attachments/assets/16a5fc22-3cba-45a1-aeca-d64db63d278a" />
New:
<img width="1488" height="873" alt="image" src="https://github.com/user-attachments/assets/df733e08-7f68-4685-be27-fb4283cebad4" />
