### PR TITLE
Fix optional chaining for sponsors in SponsorList query

### DIFF
--- a/src/pages/global-translation-leaders/_SponsorList.astro
+++ b/src/pages/global-translation-leaders/_SponsorList.astro
@@ -13,7 +13,7 @@ const SponsorListDoc = graphql(`
 `);
 
 const { data } = await graphqlClient.query(SponsorListDoc, {}).toPromise();
-const sponsors = data?.globalTranslationLeaders.items ?? [];
+const sponsors = data?.globalTranslationLeaders?.items ?? [];
 ---
 
 <div class="grid grid-cols-1 sm:grid-cols-2 xl:grid-cols-3 gap-8">


### PR DESCRIPTION
Add a second ?. on `globalTranslationLeaders` so that if the query ever fails and returns `null` data, the page renders with an empty list instead of crashing.