### PR TITLE
fix State select height on GTL form

### DIFF
--- a/src/features/address/StateSelect.tsx
+++ b/src/features/address/StateSelect.tsx
@@ -8,7 +8,7 @@ export const StateSelect = forwardRef<HTMLSelectElement, ComponentProps<'select'
         ref={ref}
         aria-label="State"
         className={[
-          'block w-full rounded-md border border-gray-300 bg-white px-3 py-2 text-sm shadow-sm',
+          'block w-full h-[2.375rem] rounded-md border border-gray-300 bg-white px-3 py-2 text-sm shadow-sm',
           'focus:outline-none focus:ring-2 focus:ring-indigo-500',
           className,
         ].join(' ')}


### PR DESCRIPTION
Fixes the State select element's height to match the other GTL form fields