### PR TITLE
fixes several pieces in the donation form and video

### DIFF
--- a/src/pages/partner/DonationForm.tsx
+++ b/src/pages/partner/DonationForm.tsx
@@ -5,7 +5,8 @@ import { CampaignEndedModal } from './CampaignEndedModal.tsx';
 import { Button } from '~/common/ui';
 
 export type DonateProps = {
-  hideInvestorType?: 'Individual' | 'Organization';
+  /** Which giver types the form allows. 'both' shows the Individual/Organization toggle. */
+  giverType?: 'both' | 'individual' | 'organization';
   enableRecurring?: boolean;
   campaignTotals?: boolean;
   forceDisabled?: boolean;
@@ -13,7 +14,8 @@ export type DonateProps = {
   campaignStartDate?: string;
   logoUrl?: string;
   logoAlt?: string;
-  giveByMailMemo?: string;
+  /** false hides the "give by check" option; { memo } shows it with an optional memo line. */
+  giveByMail?: false | { memo?: string };
   presetAmounts?: { recurring: number[]; oneTime: number[] };
   telemetry?: Telemetry;
 };
@@ -93,10 +95,14 @@ export const DonationForm = ({
                   }
                 : undefined,
             }}
-            investor={{
-              hide: formProps.hideInvestorType ? ['type'] : [],
-            }}
-            giveByMail={formProps.giveByMailMemo ? { memo: formProps.giveByMailMemo } : undefined}
+            investor={
+              formProps.giverType === 'individual'
+                ? { defaults: { type: 'Individual' }, hide: ['type'] }
+                : formProps.giverType === 'organization'
+                  ? { defaults: { type: 'Organization' }, hide: ['type'] }
+                  : undefined // 'both' (or unset): show the Individual/Organization toggle
+            }
+            giveByMail={formProps.giveByMail}
             telemetry={formProps.telemetry}
           />
         </>

--- a/src/pages/partner/DonationForm.tsx
+++ b/src/pages/partner/DonationForm.tsx
@@ -5,8 +5,8 @@ import { CampaignEndedModal } from './CampaignEndedModal.tsx';
 import { Button } from '~/common/ui';
 
 export type DonateProps = {
-  /** Which giver types the form allows. 'both' shows the Individual/Organization toggle. */
-  giverType?: 'both' | 'individual' | 'organization';
+  /** Which investor types the form allows. 'both' shows the Individual/Organization toggle. */
+  investorType?: 'both' | 'individual' | 'organization';
   enableRecurring?: boolean;
   campaignTotals?: boolean;
   forceDisabled?: boolean;
@@ -96,9 +96,9 @@ export const DonationForm = ({
                 : undefined,
             }}
             investor={
-              formProps.giverType === 'individual'
+              formProps.investorType === 'individual'
                 ? { defaults: { type: 'Individual' }, hide: ['type'] }
-                : formProps.giverType === 'organization'
+                : formProps.investorType === 'organization'
                   ? { defaults: { type: 'Organization' }, hide: ['type'] }
                   : undefined // 'both' (or unset): show the Individual/Organization toggle
             }

--- a/src/pages/partner/DonationForm.tsx
+++ b/src/pages/partner/DonationForm.tsx
@@ -1,12 +1,22 @@
-import { type ReactNode, useEffect, useState } from 'react';
+import { type ComponentProps, type ReactNode, useEffect, useState } from 'react';
 import { type Telemetry } from '~/graphql';
 import { DonationForm as NewDonationForm } from '~/features/donate';
 import { CampaignEndedModal } from './CampaignEndedModal.tsx';
 import { Button } from '~/common/ui';
 
+export type InvestorType = 'both' | 'individual' | 'organization';
+
+// Maps the selected investor type to the underlying form's `investor` prop.
+// 'both' is undefined so the Individual/Organization toggle is shown.
+const INVESTOR_CONFIG: Record<InvestorType, ComponentProps<typeof NewDonationForm>['investor']> = {
+  both: undefined,
+  individual: { defaults: { type: 'Individual' }, hide: ['type'] },
+  organization: { defaults: { type: 'Organization' }, hide: ['type'] },
+};
+
 export type DonateProps = {
   /** Which investor types the form allows. 'both' shows the Individual/Organization toggle. */
-  investorType?: 'both' | 'individual' | 'organization';
+  investorType?: InvestorType;
   enableRecurring?: boolean;
   campaignTotals?: boolean;
   forceDisabled?: boolean;
@@ -95,13 +105,7 @@ export const DonationForm = ({
                   }
                 : undefined,
             }}
-            investor={
-              formProps.investorType === 'individual'
-                ? { defaults: { type: 'Individual' }, hide: ['type'] }
-                : formProps.investorType === 'organization'
-                  ? { defaults: { type: 'Organization' }, hide: ['type'] }
-                  : undefined // 'both' (or unset): show the Individual/Organization toggle
-            }
+            investor={INVESTOR_CONFIG[formProps.investorType ?? 'both']}
             giveByMail={formProps.giveByMail}
             telemetry={formProps.telemetry}
           />

--- a/src/pages/partner/GiveFormWithTotals.astro
+++ b/src/pages/partner/GiveFormWithTotals.astro
@@ -73,7 +73,7 @@ const giveByMail = donationForm?.giveByMail?.enabled
   <DonationFormIsland
     formProps={{
       enableRecurring: false,
-      giverType: donationForm?.giverType ?? 'both',
+      investorType: donationForm?.giverType ?? 'both',
       presetAmounts: {
         oneTime: presetsFor('OneTime'),
         recurring: presetsFor('Monthly'),

--- a/src/pages/partner/GiveFormWithTotals.astro
+++ b/src/pages/partner/GiveFormWithTotals.astro
@@ -55,13 +55,11 @@ const forceDisabled = Astro.url.searchParams.get('form') === 'disabled';
 const donationForm = campaignData.donationForm;
 const DEFAULT_PRESETS = [50, 100, 300, 500, 1000];
 
-// Presets: prefer per-cadence presets, then the general amount presets, then defaults.
-// A missing OR empty list falls back so the form never renders zero preset buttons.
-const presetsFor = (cadence: 'OneTime' | 'Monthly') => {
-  const perCadence = donationForm?.cadence?.find((c) => c?.cadence === cadence)?.presets;
-  const general = donationForm?.amount?.presets;
-  return perCadence?.length ? perCadence : general?.length ? general : DEFAULT_PRESETS;
-};
+// Presets from the Sanity amount presets; falls back to defaults when missing or empty
+// so the form never renders zero preset buttons.
+const presetAmounts = donationForm?.amount?.presets?.length
+  ? donationForm.amount.presets
+  : DEFAULT_PRESETS;
 
 // Give by check: shown only when enabled in Sanity; memo line included when provided.
 const giveByMail = donationForm?.giveByMail?.enabled
@@ -75,8 +73,8 @@ const giveByMail = donationForm?.giveByMail?.enabled
       enableRecurring: false,
       investorType: donationForm?.giverType ?? 'both',
       presetAmounts: {
-        oneTime: presetsFor('OneTime'),
-        recurring: presetsFor('Monthly'),
+        oneTime: presetAmounts,
+        recurring: presetAmounts,
       },
       campaignTotals: true,
       forceDisabled,

--- a/src/pages/partner/GiveFormWithTotals.astro
+++ b/src/pages/partner/GiveFormWithTotals.astro
@@ -18,9 +18,18 @@ const { amount: fetchedAmount } = await fetchPartnerTotals(campaignData.sfCode ?
 const amountOverride = Astro.url.searchParams.get('amount');
 const totalRaised = amountOverride ? parseInt(amountOverride, 10) : fetchedAmount;
 
+// Goal = the highest end amount among the tiers currently showing (same visibility
+// rule as the cards: always-visible tiers, plus hidden ones the raised amount has unlocked).
+const visibleTiers = (campaignData.donationTiers ?? []).filter(
+  (tier) => !tier.hidden || totalRaised >= (tier.startAmount ?? Infinity),
+);
+const goalAmount = visibleTiers.length
+  ? Math.max(...visibleTiers.map((tier) => tier.endAmount ?? 0))
+  : totalRaised;
+
 const campaignTotals = {
   totalRaised,
-  goalAmount: 2000000,
+  goalAmount,
 };
 
 // ?campaign=active forces the live form state; ?campaign=notstarted forces "before start"; ?campaign=ended forces the ended state
@@ -54,18 +63,17 @@ const presetsFor = (cadence: 'OneTime' | 'Monthly') => {
   return perCadence?.length ? perCadence : general?.length ? general : DEFAULT_PRESETS;
 };
 
-// Memo: only shown when an editor enables "give by mail" and fills in a memo in Sanity.
-const giveByMailMemo =
-  donationForm?.giveByMail?.enabled && donationForm?.giveByMail?.memo
-    ? donationForm.giveByMail.memo
-    : undefined;
+// Give by check: shown only when enabled in Sanity; memo line included when provided.
+const giveByMail = donationForm?.giveByMail?.enabled
+  ? { memo: donationForm.giveByMail.memo ?? undefined }
+  : (false as const);
 ---
 
 <div class="form-card right-4 top-28 lg:fixed lg:right-8 lg:min-w-96 p-5 rounded-lg shadow-lg z-10">
   <DonationFormIsland
     formProps={{
       enableRecurring: false,
-      hideInvestorType: 'Organization',
+      giverType: donationForm?.giverType ?? 'both',
       presetAmounts: {
         oneTime: presetsFor('OneTime'),
         recurring: presetsFor('Monthly'),
@@ -76,7 +84,7 @@ const giveByMailMemo =
       campaignEndDate: overrideEndDate ?? campaignData.campaignEndDate ?? undefined,
       logoUrl: campaignData.heroImage ? sanity.image(campaignData.heroImage).url() : undefined,
       logoAlt: campaignData.heroImageAlt ?? undefined,
-      giveByMailMemo,
+      giveByMail,
       telemetry: { referrer: campaignData.campaignName ?? 'Partner' },
     }}
     disableDialog={disableDialog}

--- a/src/pages/partner/PartnerTemplate.astro
+++ b/src/pages/partner/PartnerTemplate.astro
@@ -8,6 +8,7 @@ import Hero from './Hero.astro';
 import ContentSection from './ContentSection.astro';
 import DonationCard from './DonationCard.astro';
 import GiveFormWithTotals from './GiveFormWithTotals.astro';
+import { resolveVideoEmbed } from './videoEmbed.ts';
 
 interface Props {
   campaignData: PartnerCampaign;
@@ -19,6 +20,8 @@ const campaignStart = campaignData.campaignStartDate
   ? new Date(campaignData.campaignStartDate)
   : null;
 const isAfterStart = campaignStart ? today >= campaignStart : true;
+
+const video = await resolveVideoEmbed(campaignData.video?.src);
 ---
 
 <style>
@@ -203,14 +206,26 @@ const isAfterStart = campaignStart ? today >= campaignStart : true;
         <GiveFormWithTotals disableDialog={true} campaignData={campaignData} />
       </aside>
       {
-        campaignData.video?.src && (
+        video?.kind === 'iframe' ? (
+          <div class="hero-video aspect-video w-full overflow-hidden rounded-3xl">
+            <iframe
+              src={video.src}
+              title="Campaign video"
+              class="h-full w-full"
+              frameborder="0"
+              allow="autoplay; fullscreen; picture-in-picture"
+              allowfullscreen
+              loading="lazy"
+            />
+          </div>
+        ) : video?.kind === 'file' ? (
           <video
-            src={campaignData.video.src}
-            poster={campaignData.video.poster ?? undefined}
+            src={video.src}
+            poster={campaignData.video?.poster ?? undefined}
             controls
             class="hero-video rounded-3xl"
           />
-        )
+        ) : null
       }
       <div class="bg-gradient"></div>
       {
@@ -225,7 +240,16 @@ const isAfterStart = campaignStart ? today >= campaignStart : true;
       <h2
         class="text-4xl text-center md:text-left gotham-bold tracking-tight sm:text-5xl pt-12 pb-8 lg:py-4"
       >
-        Unlock a Project.<br />Join the Mission.
+        {
+          (campaignData.projectsHeading?.trim() || 'Unlock a Project.\nJoin the Mission.')
+            .split('\n')
+            .map((line, i) => (
+              <Fragment>
+                {i > 0 && <br />}
+                {line}
+              </Fragment>
+            ))
+        }
       </h2>
       <DonationCard campaignData={campaignData} />
     </main>

--- a/src/pages/partner/partnerBySlug.groq.ts
+++ b/src/pages/partner/partnerBySlug.groq.ts
@@ -14,6 +14,7 @@ export const partnerBySlug =
   heroImageAlt,
   slug,
   video { src, poster },
+  projectsHeading,
   aboutSections[] {
     title,
     content

--- a/src/pages/partner/videoEmbed.ts
+++ b/src/pages/partner/videoEmbed.ts
@@ -1,0 +1,57 @@
+export type ResolvedVideo = { kind: 'iframe'; src: string } | { kind: 'file'; src: string } | null;
+
+const YOUTUBE = /(?:youtube\.com\/(?:watch\?v=|embed\/)|youtu\.be\/)([\w-]{6,})/;
+const VIMEO_PLAYER = /player\.vimeo\.com\/video\/\d+/;
+const VIMEO_NUMERIC = /vimeo\.com\/(?:[^/]+\/)*?(\d+)(?:\/(\w+))?/;
+const VIDEO_FILE = /\.(mp4|webm|ogg|ogv|mov|m4v)(?:[?#]|$)/i;
+
+/**
+ * Turn an editor-provided video URL into something we can actually render.
+ * - YouTube / Vimeo → an iframe embed URL
+ * - Vimeo "vanity" URLs (no numeric id) → resolved via Vimeo's oEmbed API
+ * - Direct video files (.mp4, etc.) → a native <video> source
+ */
+export async function resolveVideoEmbed(raw: string | null | undefined): Promise<ResolvedVideo> {
+  const url = raw?.trim();
+  if (!url) return null;
+
+  const youtube = url.match(YOUTUBE);
+  if (youtube) {
+    return { kind: 'iframe', src: `https://www.youtube.com/embed/${youtube[1]}` };
+  }
+
+  if (VIMEO_PLAYER.test(url)) {
+    return { kind: 'iframe', src: url };
+  }
+
+  const vimeoNumeric = url.match(VIMEO_NUMERIC);
+  if (vimeoNumeric) {
+    const [, id, hash] = vimeoNumeric;
+    return {
+      kind: 'iframe',
+      src: `https://player.vimeo.com/video/${id}${hash ? `?h=${hash}` : ''}`,
+    };
+  }
+
+  // Vimeo vanity/custom URL with no numeric id — resolve the real id via oEmbed.
+  if (/vimeo\.com\//i.test(url)) {
+    try {
+      const res = await fetch(`https://vimeo.com/api/oembed.json?url=${encodeURIComponent(url)}`);
+      if (res.ok) {
+        const data = (await res.json()) as { video_id?: number | string };
+        if (data?.video_id) {
+          return { kind: 'iframe', src: `https://player.vimeo.com/video/${data.video_id}` };
+        }
+      }
+    } catch {
+      // Network/resolution failed — fall through to the file handling below.
+    }
+  }
+
+  if (VIDEO_FILE.test(url)) {
+    return { kind: 'file', src: url };
+  }
+
+  // Unknown format — best effort as a direct file source.
+  return { kind: 'file', src: url };
+}

--- a/src/schemaTypes/partnerCampaign.ts
+++ b/src/schemaTypes/partnerCampaign.ts
@@ -1,6 +1,49 @@
 import { defineField, defineType } from 'sanity';
 import { DonationFormSchema } from '~/features/donate/sanity';
 
+// Partner campaigns reuse the shared donation form, but with a couple of changes,
+// leaving the shared schema (and the Campaign/Watermark type) untouched:
+//  - the amount "default value", "hide other", and "minimum" options are removed
+//    (only presets are used)
+//  - the complex shared "investor" field is replaced with a simple "Who can give?"
+//    selector (both / individuals only / organizations only)
+const giverTypeField = defineField({
+  name: 'giverType',
+  title: 'Who can give?',
+  type: 'string',
+  description:
+    'Controls the Individual / Organization options on the form. "Both" lets donors choose; the others lock the form to a single giver type.',
+  options: {
+    layout: 'radio',
+    list: [
+      { title: 'Individuals and organizations', value: 'both' },
+      { title: 'Individuals only', value: 'individual' },
+      { title: 'Organizations only', value: 'organization' },
+    ],
+  },
+  initialValue: 'both',
+});
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const partnerDonationForm: any = {
+  ...DonationFormSchema,
+  group: 'donationForm',
+  fields: [
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    ...(DonationFormSchema as any).fields
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      ?.filter((field: any) => field.name !== 'investor')
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      .map((field: any) =>
+        field.name === 'amount'
+          ? // eslint-disable-next-line @typescript-eslint/no-explicit-any
+            { ...field, fields: field.fields?.filter((f: any) => f.name === 'presets') }
+          : field,
+      ),
+    giverTypeField,
+  ],
+};
+
 const richTextBlock = {
   type: 'block',
   marks: {
@@ -162,6 +205,8 @@ export default defineType({
           name: 'src',
           title: 'Video URL',
           type: 'url',
+          description:
+            'Paste a Vimeo or YouTube link (a normal share link works), or a direct video file URL (.mp4).',
           validation: (Rule) => Rule.required(),
         }),
         defineField({
@@ -170,6 +215,18 @@ export default defineType({
           type: 'url',
         }),
       ],
+    }),
+
+    // Projects section heading
+    defineField({
+      name: 'projectsHeading',
+      title: 'Projects Section Heading',
+      type: 'text',
+      rows: 2,
+      group: 'content',
+      description:
+        'Heading shown above the opportunity cards. Add a line break to split it across two lines. If left blank, defaults to "Unlock a Project. / Join the Mission.".',
+      initialValue: 'Unlock a Project.\nJoin the Mission.',
     }),
 
     // About Sections
@@ -428,6 +485,6 @@ export default defineType({
       ],
     }),
 
-    { ...DonationFormSchema, group: 'donationForm' },
+    partnerDonationForm,
   ],
 });

--- a/src/schemaTypes/partnerCampaign.ts
+++ b/src/schemaTypes/partnerCampaign.ts
@@ -1,12 +1,48 @@
 import { defineField, defineType } from 'sanity';
-import { DonationFormSchema } from '~/features/donate/sanity';
 
-// Partner campaigns reuse the shared donation form, but with a couple of changes,
-// leaving the shared schema (and the Campaign/Watermark type) untouched:
-//  - the amount "default value", "hide other", and "minimum" options are removed
-//    (only presets are used)
-//  - the complex shared "investor" field is replaced with a simple "Who can give?"
-//    selector (both / individuals only / organizations only)
+// Partner campaigns define their own donation form (rather than reusing the shared
+// DonationFormSchema) so they stay fully typed and independent of that module:
+//  - amount is presets-only (no "default value", "hide other", or "minimum")
+//  - cadence is intentionally omitted (recurring/subscriptions not enabled yet)
+//  - "investor" is replaced with a simple "Who can give?" selector
+const partnerAmount = defineField({
+  name: 'amount',
+  title: 'Amount',
+  type: 'object',
+  options: { collapsible: true, collapsed: true },
+  fields: [
+    defineField({
+      name: 'presets',
+      title: 'Amount Presets',
+      type: 'array',
+      description: 'Predefined donation amount buttons.',
+      of: [{ type: 'number', validation: (rule) => rule.greaterThan(0) }],
+    }),
+  ],
+});
+
+const partnerGiveByMail = defineField({
+  name: 'giveByMail',
+  title: 'Give by Mail',
+  type: 'object',
+  options: { collapsible: true, collapsed: true },
+  fields: [
+    defineField({
+      name: 'enabled',
+      title: 'Enabled',
+      type: 'boolean',
+      description: 'Show the "give by check" option on the form.',
+      initialValue: false,
+    }),
+    defineField({
+      name: 'memo',
+      title: 'Memo',
+      type: 'string',
+      description: 'Optional memo line shown in the "give by check" instructions.',
+    }),
+  ],
+});
+
 const giverTypeField = defineField({
   name: 'giverType',
   title: 'Who can give?',
@@ -24,25 +60,13 @@ const giverTypeField = defineField({
   initialValue: 'both',
 });
 
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-const partnerDonationForm: any = {
-  ...DonationFormSchema,
+const partnerDonationForm = defineField({
+  name: 'donationForm',
+  title: 'Donation Form',
+  type: 'object',
   group: 'donationForm',
-  fields: [
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    ...(DonationFormSchema as any).fields
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      ?.filter((field: any) => field.name !== 'investor')
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      .map((field: any) =>
-        field.name === 'amount'
-          ? // eslint-disable-next-line @typescript-eslint/no-explicit-any
-            { ...field, fields: field.fields?.filter((f: any) => f.name === 'presets') }
-          : field,
-      ),
-    giverTypeField,
-  ],
-};
+  fields: [partnerAmount, partnerGiveByMail, giverTypeField],
+});
 
 const richTextBlock = {
   type: 'block',


### PR DESCRIPTION
- Donation form wired to the CMS (presets, give-by-check toggle + memo, "Who can give?" selector, removed unused amount fields; cadence left unwired)
- Progress bar goal now dynamic (visible tiers' top end vs raised)
- Video resolver (Vimeo/YouTube iframes + oEmbed fallback + file support)
- Projects Section Heading CMS field with newline support and default fallback
- projectsHeading added to the GROQ query
- Shared donate schema/component, campaign/Watermark, and GTL all untouched